### PR TITLE
Avoid crashing if LC_ALL is not defined by user

### DIFF
--- a/glances/__init__.py
+++ b/glances/__init__.py
@@ -95,7 +95,13 @@ def main():
     Run it...
     """
     # Setup translations
-    locale.setlocale(locale.LC_ALL, '')
+    try:
+        locale.setlocale(locale.LC_ALL, '')
+    except locale.Error:
+        # Setting LC_ALL to '' should not generate an error unless LC_ALL is not
+        # defined in the user environment, which can be the case when used via SSH.
+        # So simply skip this error, as python will use the C locale by default.
+        pass
     gettext.install(gettext_domain, locale_dir)
 
     # Share global var


### PR DESCRIPTION
When LC_ALL is not defined in the user environment (which is the case when I connect via SSH to both an Ubuntu and Raspbian OS), then launching glances result in an error that the '' locale setting is unsupported (line 98 in **init.py** fails).
I've added a try/except statement and if locale.Error is raised simply ignore it. It means that glances will be running with the C locale. But it is better than not running at all. :-)
